### PR TITLE
removed es6 features to be compatible with node 0.12

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var EOL = require('os').EOL
 
 var args = process.argv.slice(3)
 var cmd = process.argv.slice(2, 3)[0]
-var docs = () => {
+var docs = function() {
   console.log('usage: jsh <cmd> [args]')
   console.log('Docs: http://shelljs.org/')
 }
@@ -24,7 +24,7 @@ if (process.argv.length < 3) {
     case 'mkdir':
     case 'mv':
     case 'rm':
-      sh[cmd](...args)
+      sh[cmd].apply(null, args)
       break
     case 'cat':
     case 'grep':
@@ -33,17 +33,17 @@ if (process.argv.length < 3) {
     case 'tempdir':
     case 'test':
     case 'which':
-      console.log(sh[cmd](...args))
+      console.log(sh[cmd].apply(null, args))
       break
     case 'find':
       if (process.argv.length > 3) {
-        console.log(sh[cmd](...args).toString().replace(/,/g, EOL))
+        console.log(sh[cmd].apply(null, args).toString().replace(/,/g, EOL))
       } else {
         docs()
       }
       break
     case 'ls':
-      console.log(sh[cmd](...args).toString().replace(/,/g, EOL))
+      console.log(sh[cmd].apply(null, args).toString().replace(/,/g, EOL))
       break
     default:
       console.log('Incorrect command or command not implemented yet.')

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsh-cli",
   "version": "0.1.3",
   "description": "Wrapper to use shelljs on the command line",
-  "engines": { "node": ">=5.0" },
+  "engines": { "node": ">=0.12" },
   "bin": { "jsh": "index.js" },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
We would like to use jsh-cli in an environment where only node 0.12 is available, so I removed all es6 specific features to be compatible with 0.12. 

Checked with https://kangax.github.io/compat-table/es6/
